### PR TITLE
Show 0 B instead of 0 YB

### DIFF
--- a/numeral.js
+++ b/numeral.js
@@ -229,30 +229,31 @@
 
     function formatByteUnits (value) {
         var suffixes = ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'],
-            suffix = suffixes[suffixes.length - 1],
+            suffix = suffixes[0],
             power,
             min,
             max,
             abs = Math.abs(value),
-            matched = false;
+            matched = (abs < 1024);
 
-        for (power = 0; power < suffixes.length; ++power) {
-            min = Math.pow(1024, power);
-            max = Math.pow(1024, power + 1);
-
-            if (abs >= min && abs < max) {
-                matched = true;
-                suffix = suffixes[power];
-                if (min > 0) {
-                    value = value / min;
-                }
-                break;
-            }
-        }
-
-        // values greater than or equal to 1024 YB
         if (!matched) {
-            value = value / Math.pow(1024, suffixes.length - 1);
+            for (power = 1; power < suffixes.length; ++power) {
+                min = Math.pow(1024, power);
+                max = Math.pow(1024, power + 1);
+
+                if (abs >= min && abs < max) {
+                    matched = true;
+                    suffix = suffixes[power];
+                    value = value / min;
+                    break;
+                }
+            }
+
+            // values greater than or equal to 1024 YB
+            if (!matched) {
+                value = value / Math.pow(1024, suffixes.length - 1);
+                suffix = suffixes[suffixes.length - 1];
+            }
         }
 
         return { value: value, suffix: suffix };

--- a/tests/numeral/byteunits.js
+++ b/tests/numeral/byteunits.js
@@ -4,7 +4,11 @@ exports.byteUnits = {
     bytes: function (test) {
         var power = function(exp) { return Math.pow(1024, exp); },
             tests = [
+                [0, 'B'],
+                [0.5, 'B'],
                 [100, 'B'],
+                [1023.9, 'B'],
+                [1024, 'KB'],
                 [power(1)*2, 'KB'],
                 [power(2)*5, 'MB'],
                 [power(3)*7.343, 'GB'],
@@ -25,7 +29,7 @@ exports.byteUnits = {
         test.expect(tests.length);
 
         for (i = 0; i < tests.length; ++i) {
-            test.strictEqual(numeral(tests[i][0]).byteUnits(), tests[i][1], tests[i][1]);
+            test.strictEqual(numeral(tests[i][0]).byteUnits(), tests[i][1], tests[i][0] + ' ' + tests[i][1]);
         }
 
         test.done();

--- a/tests/numeral/format.js
+++ b/tests/numeral/format.js
@@ -123,6 +123,7 @@ exports.format = {
 
     bytes: function (test) {
         var tests = [
+                [0, '0 b', '0 B'],
                 [100,'0b','100B'],
                 [1024*2,'0 b','2 KB'],
                 [1024*1024*5,'0b','5MB'],
@@ -132,7 +133,9 @@ exports.format = {
                 [1024*1024*1024*1024*1024*1024*1024*1024*1024, '0 b', '1024 YB']
             ].reduce(function (tests, test) {
               tests.push(test);
-              tests.push([test[0] * -1, test[1], '-' + test[2]]);
+              if (test[0] > 0) {
+                tests.push([test[0] * -1, test[1], '-' + test[2]]);
+              }
               return tests;
             }, []),
             i;


### PR DESCRIPTION
With the units change, there was an unexpected change in behavior where it would so 0 YB instead of 0 B.

I updated the code and added tests to avoid this behavior.